### PR TITLE
Fix /app page 404 error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,20 @@ function App() {
               </ProtectedRoute>
             } 
           />
+          <Route 
+            path="/app" 
+            element={
+              <ProtectedRoute>
+                <div className="max-w-7xl mx-auto p-6">
+                  <Navigation 
+                    activeSection={activeSection} 
+                    onSectionChange={setActiveSection} 
+                  />
+                  {renderSection()}
+                </div>
+              </ProtectedRoute>
+            } 
+          />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>


### PR DESCRIPTION
Add `/app` route to fix 404 error when navigating from the landing page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f9da30c-2302-4356-98e1-e11ac88fbd13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f9da30c-2302-4356-98e1-e11ac88fbd13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

